### PR TITLE
Allow scrollable HubSpot iframe

### DIFF
--- a/app/style.css
+++ b/app/style.css
@@ -32,7 +32,7 @@ h1 {
 
 #signup-form {
   max-width: 500px;
-  height: 80%;
+  height: 70%;
   overflow: scroll;
   margin: 0px auto;
   padding: 0px 10px;

--- a/app/style.css
+++ b/app/style.css
@@ -32,6 +32,8 @@ h1 {
 
 #signup-form {
   max-width: 500px;
+  height: 80%;
+  overflow: scroll;
   margin: 0px auto;
   padding: 0px 10px;
   border-radius: 20px;


### PR DESCRIPTION
This ensures that longer HubSpot forms still work, and don't hide away the confirm button.